### PR TITLE
Feature for deep arguments as optional

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -25,13 +25,20 @@ const argv = yargs
       type: 'boolean',
     },
   })
+  .options({
+    deep: {
+      default: true,
+      description: 'Sort on fields',
+      type: 'boolean',
+    },
+  })
   .parse();
 
 const resolvedPath = path.resolve(argv.sdlPath);
 
 const inputSdl = fs.readFileSync(resolvedPath, 'utf8');
 
-const outputSdl = formatSdl(inputSdl);
+const outputSdl = formatSdl(inputSdl, {deep: argv.deep});
 
 if (argv.write) {
   fs.writeFileSync(resolvedPath, outputSdl);

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -26,9 +26,23 @@ const argv = yargs
     },
   })
   .options({
-    deep: {
+    'sort-definitions': {
+      default: true,
+      description: 'Sort on definitions',
+      type: 'boolean',
+    },
+  })
+  .options({
+    'sort-fields': {
       default: true,
       description: 'Sort on fields',
+      type: 'boolean',
+    },
+  })
+  .options({
+    'sort-arguments': {
+      default: true,
+      description: 'Sort on arguments',
       type: 'boolean',
     },
   })
@@ -38,9 +52,20 @@ const resolvedPath = path.resolve(argv.sdlPath);
 
 const inputSdl = fs.readFileSync(resolvedPath, 'utf8');
 
-const outputSdl = formatSdl(inputSdl, {deep: argv.deep});
+const {
+  write,
+  sortArguments,
+  sortDefinitions,
+  sortFields,
+} = argv;
 
-if (argv.write) {
+const outputSdl = formatSdl(inputSdl, {
+  sortArguments,
+  sortDefinitions,
+  sortFields,
+});
+
+if (write) {
   fs.writeFileSync(resolvedPath, outputSdl);
 
   // eslint-disable-next-line no-console

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -19,30 +19,24 @@ const argv = yargs
     });
   })
   .options({
-    write: {
-      default: false,
-      description: 'Overrides contents of the SDL document.',
+    'sort-arguments': {
+      default: true,
+      description: 'Sort on arguments',
       type: 'boolean',
     },
-  })
-  .options({
     'sort-definitions': {
       default: true,
       description: 'Sort on definitions',
       type: 'boolean',
     },
-  })
-  .options({
     'sort-fields': {
       default: true,
       description: 'Sort on fields',
       type: 'boolean',
     },
-  })
-  .options({
-    'sort-arguments': {
-      default: true,
-      description: 'Sort on arguments',
+    write: {
+      default: false,
+      description: 'Overrides contents of the SDL document.',
       type: 'boolean',
     },
   })

--- a/src/utilities/formatSdl.js
+++ b/src/utilities/formatSdl.js
@@ -6,7 +6,13 @@ import {
   parse,
 } from 'graphql';
 
-export default (schemaSdl: string): string => {
+type SortOptionsType = {|
+  deep: ?boolean,
+|};
+
+export default (schemaSdl: string, options: ?SortOptionsType): string => {
+  const {deep = true} = options || {};
+
   return print(mapObject(parse(schemaSdl), (key, value) => {
     if ((key === 'fields' || key === 'definitions') && Array.isArray(value)) {
       return [
@@ -22,6 +28,6 @@ export default (schemaSdl: string): string => {
       value,
     ];
   }, {
-    deep: true,
+    deep,
   }));
 };

--- a/src/utilities/formatSdl.js
+++ b/src/utilities/formatSdl.js
@@ -5,22 +5,39 @@ import {
   print,
   parse,
 } from 'graphql';
+import {getOptions} from './optionalize';
+import type {OptionsType} from './optionalize';
 
-type SortOptionsType = {|
-  deep: ?boolean,
-|};
+const sortSchema = (key, value, options: OptionsType) => {
+  const {
+    sortArguments,
+    sortDefinitions,
+    sortFields,
+  } = options;
 
-export default (schemaSdl: string, options: ?SortOptionsType): string => {
-  const {deep = true} = options || {};
+  if (
+    sortDefinitions && key === 'definitions' ||
+    sortFields && key === 'fields' ||
+    sortArguments && key === 'arguments'
+  ) {
+    return [
+      key,
+      value.slice().sort((a, b) => {
+        return a.name.value.localeCompare(b.name.value);
+      }),
+    ];
+  }
 
+  return [
+    key,
+    value,
+  ];
+};
+
+export default (schemaSdl: string, options?: $Shape<OptionsType>): string => {
   return print(mapObject(parse(schemaSdl), (key, value) => {
-    if ((key === 'fields' || key === 'definitions') && Array.isArray(value)) {
-      return [
-        key,
-        value.slice().sort((a, b) => {
-          return a.name.value.localeCompare(b.name.value);
-        }),
-      ];
+    if (['definitions', 'fields', 'arguments'].includes(key) && Array.isArray(value)) {
+      return sortSchema(key, value, getOptions(options));
     }
 
     return [
@@ -28,6 +45,6 @@ export default (schemaSdl: string, options: ?SortOptionsType): string => {
       value,
     ];
   }, {
-    deep,
+    deep: true,
   }));
 };

--- a/src/utilities/optionalize.js
+++ b/src/utilities/optionalize.js
@@ -1,0 +1,43 @@
+// @flow
+
+type SortOptionsType = {|
+  sortDefinitions: boolean,
+  sortFields: boolean,
+  sortArguments: boolean,
+|};
+
+type OptionsType = SortOptionsType;
+
+const isBoolean = (value): %checks => {
+  return typeof value === 'boolean';
+};
+
+const toBoolean = (value, defaultValue?: boolean): boolean => {
+  if (isBoolean(value)) {
+    return value;
+  }
+
+  return isBoolean(defaultValue) ? defaultValue : Boolean(value);
+};
+
+const getSortOptions = (options?: $Shape<SortOptionsType>): SortOptionsType => {
+  const {
+    sortArguments,
+    sortDefinitions,
+    sortFields,
+  } = options || {};
+
+  return {
+    sortArguments: toBoolean(sortArguments, true),
+    sortDefinitions: toBoolean(sortDefinitions, true),
+    sortFields: toBoolean(sortFields, true),
+  };
+};
+
+export const getOptions = (options?: $Shape<OptionsType>): OptionsType => {
+  const sortOptions = getSortOptions(options);
+
+  return sortOptions;
+};
+
+export type {OptionsType};

--- a/src/utilities/optionalize.js
+++ b/src/utilities/optionalize.js
@@ -8,11 +8,12 @@ type SortOptionsType = {|
 
 type OptionsType = SortOptionsType;
 
-const isBoolean = (value): %checks => {
+// eslint-disable-next-line flowtype/no-weak-types
+const isBoolean = (value: any): %checks => {
   return typeof value === 'boolean';
 };
 
-const toBoolean = (value, defaultValue?: boolean): boolean => {
+const toBoolean = <T>(value: T, defaultValue?: boolean): boolean => {
   if (isBoolean(value)) {
     return value;
   }
@@ -34,10 +35,15 @@ const getSortOptions = (options?: $Shape<SortOptionsType>): SortOptionsType => {
   };
 };
 
-export const getOptions = (options?: $Shape<OptionsType>): OptionsType => {
+const getOptions = (options?: $Shape<OptionsType>): OptionsType => {
   const sortOptions = getSortOptions(options);
 
   return sortOptions;
 };
 
+export {
+  isBoolean,
+  toBoolean,
+  getOptions,
+};
 export type {OptionsType};

--- a/test/sort-graphql-sdl/utilities/formatSdl.js
+++ b/test/sort-graphql-sdl/utilities/formatSdl.js
@@ -94,41 +94,91 @@ test.skip('does not strip comments', (t) => {
   t.is(formatSdl(input), expectedOutput);
 });
 
-test('does not sort fields with false deep argument', (t) => {
+test('does not sort definitions when sort argument is false', (t) => {
   const input = `
   type Foo {
-    a: ID
-    c: ID
-    b: ID
+    foo: ID
+  }
+
+  type Bar {
+    bar: ID
   }
 `;
 
   const expectedOutput = `type Foo {
-  a: ID
-  c: ID
-  b: ID
+  foo: ID
+}
+
+type Bar {
+  bar: ID
 }
 `;
 
-  t.is(formatSdl(input, {deep: false}), expectedOutput);
+  t.is(formatSdl(input, {sortDefinitions: false}), expectedOutput);
 });
 
-test('sort fields whether deep is true or non exist', (t) => {
+test('does not sort fields when sort argument is false', (t) => {
   const input = `
   type Foo {
-    a: ID
-    c: ID
-    b: ID
+    apple: ID
+    cat: ID
+    banana: ID
   }
 `;
 
   const expectedOutput = `type Foo {
-  a: ID
-  b: ID
-  c: ID
+  apple: ID
+  cat: ID
+  banana: ID
+}
+`;
+
+  t.is(formatSdl(input, {sortFields: false}), expectedOutput);
+});
+
+test('does not sort arguments when sort argument is false', (t) => {
+  const input = `
+  type Foo {
+    bar(banana: ID, cat: ID, apple: ID): ID!
+  }
+`;
+
+  const expectedOutput = `type Foo {
+  bar(banana: ID, cat: ID, apple: ID): ID!
+}
+`;
+
+  t.is(formatSdl(input, {sortArguments: false}), expectedOutput);
+});
+
+test('sort whether sort options is true or non exist', (t) => {
+  const input = `
+  type Foo {
+    apple: ID
+    cat: ID
+    banana: ID
+  }
+
+  type Bar {
+    bar(banana: ID, cat: ID, apple: ID): ID!
+  }
+`;
+
+  const expectedOutput = `type Bar {
+  bar(apple: ID, banana: ID, cat: ID): ID!
+}
+
+type Foo {
+  apple: ID
+  banana: ID
+  cat: ID
 }
 `;
 
   t.is(formatSdl(input), expectedOutput);
-  t.is(formatSdl(input, {deep: true}), expectedOutput);
+  t.is(formatSdl(input, {
+    sortArguments: true,
+    sortDefinitions: true,
+    sortFields: true,
+  }), expectedOutput);
 });

--- a/test/sort-graphql-sdl/utilities/formatSdl.js
+++ b/test/sort-graphql-sdl/utilities/formatSdl.js
@@ -93,3 +93,42 @@ test.skip('does not strip comments', (t) => {
 
   t.is(formatSdl(input), expectedOutput);
 });
+
+test('does not sort fields with false deep argument', (t) => {
+  const input = `
+  type Foo {
+    a: ID
+    c: ID
+    b: ID
+  }
+`;
+
+  const expectedOutput = `type Foo {
+  a: ID
+  c: ID
+  b: ID
+}
+`;
+
+  t.is(formatSdl(input, {deep: false}), expectedOutput);
+});
+
+test('sort fields whether deep is true or non exist', (t) => {
+  const input = `
+  type Foo {
+    a: ID
+    c: ID
+    b: ID
+  }
+`;
+
+  const expectedOutput = `type Foo {
+  a: ID
+  b: ID
+  c: ID
+}
+`;
+
+  t.is(formatSdl(input), expectedOutput);
+  t.is(formatSdl(input, {deep: true}), expectedOutput);
+});

--- a/test/sort-graphql-sdl/utilities/optionalize.js
+++ b/test/sort-graphql-sdl/utilities/optionalize.js
@@ -40,31 +40,3 @@ test('get sort options when proper value type addressed', (t) => {
 
   t.deepEqual(actual, expected);
 });
-
-// test('get sort options when argv value is in-proper', (t) => {
-//   const inputs = [false, null, '', 0, NaN];
-//   const expected = {
-//     sortArguments: true,
-//     sortDefinitions: true,
-//     sortFields: true,
-//   };
-
-//   inputs.forEach((input) => {
-//     t.deepEqual(getOptions(input), expected);
-//   });
-// });
-
-// test('get sort options when option value is in-proper', (t) => {
-//   const inputs = [undefined, null, '', 0, NaN];
-//   const expected = {
-//     sortArguments: true,
-//     sortDefinitions: true,
-//     sortFields: true,
-//   };
-
-//   inputs.forEach((value) => {
-//     t.deepEqual(getOptions({
-//       sortDefinitions: value,
-//     }), expected);
-//   });
-// });

--- a/test/sort-graphql-sdl/utilities/optionalize.js
+++ b/test/sort-graphql-sdl/utilities/optionalize.js
@@ -1,7 +1,7 @@
 // @flow
 
 import test from 'ava';
-import {getOptions} from '../../../src/utilities/optionalize';
+import {getOptions, toBoolean, isBoolean} from '../../../src/utilities/optionalize';
 
 test('get sort options when no args', (t) => {
   const input = undefined;
@@ -39,4 +39,34 @@ test('get sort options when proper value type addressed', (t) => {
   const actual = getOptions(input);
 
   t.deepEqual(actual, expected);
+});
+
+test('to boolean with proper value addressed', (t) => {
+  const inputs = [true, false];
+
+  inputs.forEach((input) => {
+    const actual = isBoolean(toBoolean(input));
+
+    t.true(actual);
+  });
+});
+
+test('to boolean with in-proper value addressed', (t) => {
+  const inputs = [null, undefined, 0, '', NaN];
+
+  inputs.forEach((input) => {
+    const actual = toBoolean(input);
+
+    t.false(actual);
+  });
+});
+
+test('to boolean with in-proper value addressed and default true', (t) => {
+  const inputs = [null, undefined, 0, '', NaN];
+
+  inputs.forEach((input) => {
+    const actual = toBoolean(input, true);
+
+    t.true(actual);
+  });
 });

--- a/test/sort-graphql-sdl/utilities/optionalize.js
+++ b/test/sort-graphql-sdl/utilities/optionalize.js
@@ -1,0 +1,70 @@
+// @flow
+
+import test from 'ava';
+import {getOptions} from '../../../src/utilities/optionalize';
+
+test('get sort options when no args', (t) => {
+  const input = undefined;
+  const expected = {
+    sortArguments: true,
+    sortDefinitions: true,
+    sortFields: true,
+  };
+  const actual = getOptions(input);
+
+  t.deepEqual(actual, expected);
+});
+
+test('get sort options when empty object', (t) => {
+  const input = {};
+  const expected = {
+    sortArguments: true,
+    sortDefinitions: true,
+    sortFields: true,
+  };
+  const actual = getOptions(input);
+
+  t.deepEqual(actual, expected);
+});
+
+test('get sort options when proper value type addressed', (t) => {
+  const input = {
+    sortDefinitions: false,
+  };
+  const expected = {
+    sortArguments: true,
+    sortDefinitions: false,
+    sortFields: true,
+  };
+  const actual = getOptions(input);
+
+  t.deepEqual(actual, expected);
+});
+
+// test('get sort options when argv value is in-proper', (t) => {
+//   const inputs = [false, null, '', 0, NaN];
+//   const expected = {
+//     sortArguments: true,
+//     sortDefinitions: true,
+//     sortFields: true,
+//   };
+
+//   inputs.forEach((input) => {
+//     t.deepEqual(getOptions(input), expected);
+//   });
+// });
+
+// test('get sort options when option value is in-proper', (t) => {
+//   const inputs = [undefined, null, '', 0, NaN];
+//   const expected = {
+//     sortArguments: true,
+//     sortDefinitions: true,
+//     sortFields: true,
+//   };
+
+//   inputs.forEach((value) => {
+//     t.deepEqual(getOptions({
+//       sortDefinitions: value,
+//     }), expected);
+//   });
+// });


### PR DESCRIPTION
Hello. I think `deep` arguments would be better as optional. I intentionally maintain the schema field order, which makes it uncomfortable to sort. So, I added feature with compatibility. 😃 