### PR TITLE
Feature for order of special keyword

### DIFF
--- a/src/utilities/formatSdl.js
+++ b/src/utilities/formatSdl.js
@@ -5,10 +5,30 @@ import {
   print,
   parse,
 } from 'graphql';
+import {
+  isSpecialkeyword,
+  specialKeywordCompare,
+} from './isSpecialKeyword';
 
 export default (schemaSdl: string): string => {
   return print(mapObject(parse(schemaSdl), (key, value) => {
-    if ((key === 'fields' || key === 'definitions') && Array.isArray(value)) {
+    if (key === 'definitions' && Array.isArray(value)) {
+      return [
+        key,
+        value.slice().sort((a, b) => {
+          const left = a.name.value;
+          const right = b.name.value;
+
+          if (isSpecialkeyword(left) || isSpecialkeyword(right)) {
+            return specialKeywordCompare(left, right);
+          }
+
+          return left.localeCompare(right);
+        }),
+      ];
+    }
+
+    if (key === 'fields' && Array.isArray(value)) {
       return [
         key,
         value.slice().sort((a, b) => {

--- a/src/utilities/isSpecialKeyword.js
+++ b/src/utilities/isSpecialKeyword.js
@@ -1,0 +1,36 @@
+// @flow
+
+type CheckType = string | boolean | null;
+
+/* eslint-disable sort-keys */
+// Order for special keywords
+const highestPriority = {
+  schema: 0,
+  Query: 1,
+  Mutation: 2,
+  Subscription: 3,
+};
+/* eslint-enable sort-keys */
+
+const getSpecialKeywordOrder = (name: string): number => {
+  return highestPriority[name];
+};
+
+export const isSpecialkeyword = (name: ?CheckType): boolean => {
+  return typeof name === 'string' && typeof getSpecialKeywordOrder(name) === 'number';
+};
+
+export const specialKeywordCompare = (left: string, right: string): number => {
+  const leftIsSpecial = isSpecialkeyword(left);
+  const rightIsSpecial = isSpecialkeyword(right);
+
+  if (leftIsSpecial && rightIsSpecial) {
+    return getSpecialKeywordOrder(left) - getSpecialKeywordOrder(right);
+  } else if (leftIsSpecial) {
+    return -1;
+  } else if (rightIsSpecial) {
+    return 1;
+  }
+
+  return 0;
+};

--- a/test/sort-graphql-sdl/utilities/isSpecialKeyword.js
+++ b/test/sort-graphql-sdl/utilities/isSpecialKeyword.js
@@ -1,0 +1,46 @@
+// @flow
+
+import test from 'ava';
+import {
+  isSpecialkeyword,
+  specialKeywordCompare,
+} from '../../../src/utilities/isSpecialKeyword';
+
+test('test special keywords', (t) => {
+  const inputs = ['Query', 'Mutation', 'Subscription', 'schema'];
+  const expectedOutput = true;
+
+  inputs.forEach((input) => {
+    t.is(isSpecialkeyword(input), expectedOutput);
+  });
+});
+
+test('distinguish not special keyword', (t) => {
+  const input = 'User';
+  const expectedOutput = false;
+
+  t.is(isSpecialkeyword(input), expectedOutput);
+});
+
+test('distinguish falsy case as false', (t) => {
+  const inputs = ['', false, null, undefined];
+  const expectedOutput = false;
+
+  inputs.forEach((input) => {
+    t.is(isSpecialkeyword(input), expectedOutput);
+  });
+});
+
+test('schema has highest order between special keywords', (t) => {
+  const input = 'schema';
+  const targets = ['Query', 'Mutation', 'Subscription'];
+  const lowerThanZero = (value: number): boolean => {
+    return value < 0;
+  };
+
+  targets.forEach((target) => {
+    const actualOutput = specialKeywordCompare(input, target);
+
+    t.is(lowerThanZero(actualOutput), true);
+  });
+});


### PR DESCRIPTION
I think Four special keyword have to be separated from sorting target. These should be on top of schema because of their speciality. I think it also can be nice to adopted as cli option. It's just feature request 😃 
- `schema`, `Query`, `Mutation`, `Subscription`