### PR TITLE
Fix README.md: Command for overriding target schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ # Prints formatted schema.
 $ format-graphql ./schema.graphql
 $
 $ # Overrides target schema.
-$ format-graphql --write ./schema.graphql
+$ format-graphql --write=true ./schema.graphql
 
 ```
 


### PR DESCRIPTION
The arguments `--write` require `true` to work. Fixing that in README.md