### PR TITLE
Expose a node api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Formats GraphQL schema definition language (SDL) document.
 * [Behaviour](#behaviour)
   * [Example](#example)
 * [Usage](#usage)
+  * [Command Line](#command-line)
+  * [Node API](#node-api)
   * [Hooks](#hooks)
 
 ## Motivation
@@ -69,6 +71,8 @@ type Query {
 
 ## Usage
 
+### Command Line
+
 ```bash
 $ format-graphql --help
 Sort GraphQL schema definition language (SDL) document.
@@ -91,6 +95,33 @@ $
 $ # Overrides target schema.
 $ format-graphql --write=true ./schema.graphql
 
+```
+
+### Node API
+
+`formatSdl(schema, options)`
+
+Returns a formatted GraphQL SDL String.
+
+**Parameters**
+
+- `schema`: string
+- `options` (optional): object:
+
+  ```
+  {
+    sortDefinitions?: boolean,
+    sortFields?: boolean,
+    sortArguments?: boolean,
+  }
+  ```
+
+**Example**
+
+```js
+import {formatSdl} from 'format-graphql';
+
+formatGraphql('type Foo { bar: String }');
 ```
 
 ### Hooks

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export {default as formatSdl} from './utilities/formatSdl';


### PR DESCRIPTION
(Fixes https://github.com/gajus/format-graphql/issues/9)

`package.json#main` refers to a non-existent file:
https://github.com/gajus/format-graphql/blob/0f08ce36dcf3ce2567055f6fccc6326efea16bcf/package.json#L65

This PR adds the file as expected.

(The alternative is to point `package.json#main` to `dist/utilities/formatSdl.js`, not sure which you prefer)