### PR TITLE
Sort definitions by kind and then alphabetically

### DIFF
--- a/test/format-graphql/utilities/formatSdl.js
+++ b/test/format-graphql/utilities/formatSdl.js
@@ -207,6 +207,173 @@ type Foo {
   }), expectedOutput);
 });
 
+test('sorts definitions according to their kind', (t) => {
+  const input = `
+  extend interface Person {
+    lastName: String
+  }
+
+  extend union Union = QueryType
+
+  extend type Foo {
+    bar: String
+  }
+
+  union Union = Foo | Bar
+
+  interface Person {
+    firstName: String
+  }
+
+  interface Node {
+    id: ID!
+  }
+
+  type QueryType {
+    query: String
+  }
+
+  extend schema {
+    mutation: Mutation
+  }
+
+  directive @upper on FIELD_DEFINITION
+
+  type Foo {
+    id: ID
+  }
+
+  directive @lower on FIELD_DEFINITION
+
+  extend type Mutation {
+    doSomethingElse: String
+  }
+
+  extend enum Flavor {
+    CHOCOLATE
+  }
+
+  scalar JSON
+
+  input Order {
+    flavor: Flavor
+  }
+
+  schema {
+    query: QueryType
+  }
+
+  type Mutation {
+    doSomething: String
+  }
+
+  extend scalar Date @serialize
+
+  directive @serialize on SCALAR
+
+  enum Flavor {
+    VANILLA
+  }
+
+  extend input Order {
+    quantity: Int
+  }
+
+  scalar Date
+
+  type Bar {
+    id: ID
+  }
+
+  extend type Bar {
+    bar: String
+  }
+`;
+
+  const expectedOutput = `schema {
+  query: QueryType
+}
+
+extend schema {
+  mutation: Mutation
+}
+
+scalar Date
+
+extend scalar Date @serialize
+
+scalar JSON
+
+directive @lower on FIELD_DEFINITION
+
+directive @serialize on SCALAR
+
+directive @upper on FIELD_DEFINITION
+
+type QueryType {
+  query: String
+}
+
+type Mutation {
+  doSomething: String
+}
+
+extend type Mutation {
+  doSomethingElse: String
+}
+
+type Bar {
+  id: ID
+}
+
+extend type Bar {
+  bar: String
+}
+
+type Foo {
+  id: ID
+}
+
+extend type Foo {
+  bar: String
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Person {
+  firstName: String
+}
+
+extend interface Person {
+  lastName: String
+}
+
+union Union = Foo | Bar
+
+extend union Union = QueryType
+
+input Order {
+  flavor: Flavor
+}
+
+extend input Order {
+  quantity: Int
+}
+
+enum Flavor {
+  VANILLA
+}
+
+extend enum Flavor {
+  CHOCOLATE
+}
+`;
+
+  t.is(formatSdl(input), expectedOutput);
+});
+
 // Regression test for https://github.com/gajus/format-graphql/issues/10
 test('does not fail for large schemas', (t) => {
   const input = generateSchema(1000, 1);


### PR DESCRIPTION
This change additionally sorts definitions by kind in an opinionated way. Each group of types is still sorted alphabetically:

* Schema
* Scalars
* Directives
* Query operation type
* Mutation operation type
* Subscription operation type
* All other object types
* Interfaces
* Unions
* Input object types
* Enums

Any type system extensions will appear after the type being extended.

I can make this configurable through a flag if it seems like too much of a change to have as the default behavior.