### PR TITLE
feat: sort enums with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Options:
   --help              Show help                                        [boolean]
   --sort-arguments    Sort on arguments                [boolean] [default: true]
   --sort-definitions  Sort on definitions              [boolean] [default: true]
+  --sort-enums        Sort on enums                    [boolean] [default: true]
   --sort-fields       Sort on fields                   [boolean] [default: true]
   --write             Overrides contents of the SDL document.
                                                       [boolean] [default: false]
@@ -111,6 +112,7 @@ Returns a formatted GraphQL SDL String.
   ```
   {
     sortDefinitions?: boolean,
+    sortEnums?: boolean,
     sortFields?: boolean,
     sortArguments?: boolean,
   }

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -29,6 +29,11 @@ const argv = yargs
       description: 'Sort on definitions',
       type: 'boolean',
     },
+    'sort-enums': {
+      default: true,
+      description: 'Sort on enums',
+      type: 'boolean',
+    },
     'sort-fields': {
       default: true,
       description: 'Sort on fields',
@@ -50,12 +55,14 @@ const {
   write,
   sortArguments,
   sortDefinitions,
+  sortEnums,
   sortFields,
 } = argv;
 
 const outputSdl = formatSdl(inputSdl, {
   sortArguments,
   sortDefinitions,
+  sortEnums,
   sortFields,
 });
 

--- a/src/utilities/optionalize.js
+++ b/src/utilities/optionalize.js
@@ -2,6 +2,7 @@
 
 type SortOptionsType = {|
   sortDefinitions: boolean,
+  sortEnums: boolean,
   sortFields: boolean,
   sortArguments: boolean,
 |};
@@ -25,12 +26,14 @@ const getSortOptions = (options?: $Shape<SortOptionsType>): SortOptionsType => {
   const {
     sortArguments,
     sortDefinitions,
+    sortEnums,
     sortFields,
   } = options || {};
 
   return {
     sortArguments: toBoolean(sortArguments, true),
     sortDefinitions: toBoolean(sortDefinitions, true),
+    sortEnums: toBoolean(sortEnums, true),
     sortFields: toBoolean(sortFields, true),
   };
 };

--- a/test/format-graphql/utilities/formatSdl.js
+++ b/test/format-graphql/utilities/formatSdl.js
@@ -67,6 +67,23 @@ test('sorts fields', (t) => {
   t.is(formatSdl(input), expectedOutput);
 });
 
+test('sorts enum values', (t) => {
+  const input = `
+  enum Foo {
+    FOO
+    BAR
+  }
+`;
+
+  const expectedOutput = `enum Foo {
+  BAR
+  FOO
+}
+`;
+
+  t.is(formatSdl(input), expectedOutput);
+});
+
 test('does not sort parameters', (t) => {
   const input = `
   type Foo {

--- a/test/format-graphql/utilities/optionalize.js
+++ b/test/format-graphql/utilities/optionalize.js
@@ -8,6 +8,7 @@ test('get sort options when no args', (t) => {
   const expected = {
     sortArguments: true,
     sortDefinitions: true,
+    sortEnums: true,
     sortFields: true,
   };
   const actual = getOptions(input);
@@ -20,6 +21,7 @@ test('get sort options when empty object', (t) => {
   const expected = {
     sortArguments: true,
     sortDefinitions: true,
+    sortEnums: true,
     sortFields: true,
   };
   const actual = getOptions(input);
@@ -34,6 +36,7 @@ test('get sort options when proper value type addressed', (t) => {
   const expected = {
     sortArguments: true,
     sortDefinitions: false,
+    sortEnums: true,
     sortFields: true,
   };
   const actual = getOptions(input);


### PR DESCRIPTION
This commit adds the functionality to sort enums, under the `--sort-enums` option flag.
I tried to make it as unintrusive as possible by adding the `node.kind` check too.

Fixes: https://github.com/gajus/format-graphql/issues/8